### PR TITLE
Add simple completion for `:ConvertColorTo`

### DIFF
--- a/plugin/colors.vim
+++ b/plugin/colors.vim
@@ -371,4 +371,9 @@ function! ConvertColorTo(...) range abort
 	echom 'Converted '.l:converted_data['match'].' -> '.l:converted_data['color_string']
 endfunction
 
-command! -nargs=* -range ConvertColorTo <line1>,<line2>call ConvertColorTo(<f-args>)
+command! -nargs=* -range -complete=custom,s:CompleteConvertColorTo
+      \ ConvertColorTo <line1>,<line2>call ConvertColorTo(<f-args>)
+
+function! s:CompleteConvertColorTo(arg_lead, cmd_line, cursor_pos)
+  return join(sort(keys(s:Formatters)), "\n")
+endfunction


### PR DESCRIPTION
This makes the `:ConvertColorTo` command a bit easier to use, I think, with completion for the possible conversion options the plugin provides.

It's a bit *too* simple -- this will complete both the first and the second argument, and only the first one is the color. I could split `a:arg_lead` and `a:cmd_line` by whitespace and confirm which argument is being completed, but I felt that maybe it's not worth the additional code. Let me know what you think.